### PR TITLE
Fix/#107/마이페이지 정당 로고 이미지 최적화

### DIFF
--- a/app/mypage/components/Party/PartyItem.tsx
+++ b/app/mypage/components/Party/PartyItem.tsx
@@ -5,13 +5,13 @@ import { FollowingPartyType } from '@/types';
 export default function PartyItem({ party_id, party_name, party_image_url }: FollowingPartyType) {
   return (
     <Link href={`/party/${party_id}`}>
-      <div className="w-[132px] h-[102px] rounded-lg mr-[10px] border-[2px]">
+      <div className="w-[132px] h-[102px] rounded-lg mr-[10px] border-[2px] flex justify-center items-center bg-white">
         <Image
           src={process.env.NEXT_PUBLIC_IMAGE_URL + party_image_url}
-          width={132}
-          height={102}
+          width={100}
+          height={40}
           alt={`${party_name} 로고 이미지`}
-          className="object-cover w-[132px] h-[102px] rounded-lg"
+          className="object-cover w-[100px] h-[40px] rounded-lg"
         />
       </div>
     </Link>


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- #101 
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

### 1. Image 컴포넌트 사이즈 132, 102 => 100, 40 으로 변경
- a466ac2a3a9c1c84fee076b92c8f4cade0ce2372
<br>

## 5. 추가 사항
